### PR TITLE
Update import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm i trix
 ```
 
 ```jsx
-import trix from 'trix'
+import "trix/dist/trix";
 ```
 
 If you're using npm version with SSR make sure to import trix on page level.


### PR DESCRIPTION
Per #12 , I _believe_ that the README should be updated show the import as `import trix/dist/trix`.  This is the only thing that worked for me (I'm using `yarn` and [`create-react-app`](https://github.com/facebook/create-react-app)).