### PR TITLE
Enable react-trix to work with React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "typescript": "^3.6.4"
   },
   "peerDependencies": {
-    "react": ">=16.0 < 17",
-    "react-dom": ">=16.0 < 17"
+    "react": ">=16.0",
+    "react-dom": ">=16.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Since React 17 is out we should make sure people can use this package with it. 

Have seen no issues running this with react 17 for the last couple of weeks.